### PR TITLE
Fix millis rollover

### DIFF
--- a/arduino-staircase-lights.ino
+++ b/arduino-staircase-lights.ino
@@ -13,6 +13,16 @@ unsigned long lastTimeDetected=0;
 // the loop function runs over and over again forever
 void loop() {
 
+/**
+  lastTimeDetected should always be >= than millis()
+  if this is not the case, is because millis() had an overflow
+  and it is starting from 0 again
+**/
+  if (millis() < lastTimeDetected) { // Reset on rollover 
+    digitalWrite(RELAY, LOW);
+    lastTimeDetected = 0 
+  }
+  
   int sensorValue = digitalRead(IR_RECEIVER);
 
   if (sensorValue == 0 ) {
@@ -21,11 +31,6 @@ void loop() {
     // millis(): Returns the number of milliseconds passed since the Arduino board began running the current program. 
     // This number will overflow (go back to zero), after approximately 50 days.
     lastTimeDetected= millis() ; 
-  }
-
-  if (millis() < 1000 && lastTimeDetected > 0) { // Reset on rollover 
-    digitalWrite(RELAY, LOW);
-    lastTimeDetected = 0 
   }
 
   if (lastTimeDetected + TIME_TO_WAIT < millis() ) {

--- a/arduino-staircase-lights.ino
+++ b/arduino-staircase-lights.ino
@@ -4,7 +4,6 @@
 void setup() {
     pinMode(RELAY, OUTPUT);
   digitalWrite(RELAY, LOW);
- // Serial.begin(9600);
 
 }
 
@@ -23,11 +22,12 @@ void loop() {
     // This number will overflow (go back to zero), after approximately 50 days.
     lastTimeDetected= millis() ; 
   }
-  /*Serial.print("sensor");
-  Serial.println(sensorValue);
-  Serial.print("lastTimeDetected");
-  Serial.println(lastTimeDetected);
-*/
+
+  if (millis() < 1000 && lastTimeDetected > 0) { // Reset on rollover 
+    digitalWrite(RELAY, LOW);
+    lastTimeDetected = 0 
+  }
+
   if (lastTimeDetected + TIME_TO_WAIT < millis() ) {
     digitalWrite(RELAY, LOW);
 

--- a/arduino-staircase-lights.ino
+++ b/arduino-staircase-lights.ino
@@ -20,7 +20,7 @@ void loop() {
 **/
   if (millis() < lastTimeDetected) { // Reset on rollover 
     digitalWrite(RELAY, LOW);
-    lastTimeDetected = 0 
+    lastTimeDetected = 0;
   }
   
   int sensorValue = digitalRead(IR_RECEIVER);


### PR DESCRIPTION
> Millis() function itself Unsigned long 32bit variable. Meaning 2^32-1 milliseconds range (no negative numbers possible). This equates to: (2^32-1) / 1000ms / 60sec / 60min / 24hr = 49.71 days. Or 49 days and 17 hours. Millis() is derived from timer0_millis, and overflows result in the number returning to zero (and continuing counting from zero). Overflows do not crash the arduino, Millis() overflows do not crash your code, and the timer will not stop counting. However, if you want events to happen fewer than once every 50 days, you should use RTC and the time library.

https://forum.arduino.cc/t/resetting-millis-to-zero-reset-clock/180147

Another option (change operations) 
https://www.norwegiancreations.com/2018/10/arduino-tutorial-avoiding-the-overflow-issue-when-using-millis-and-micros/